### PR TITLE
[project/#13-path-alias] path alias & craco config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+craco.config.js

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,0 +1,14 @@
+const path = require('path');
+module.exports = {
+  webpack: {
+    alias: {
+      '~': path.resolve(__dirname, 'src'),
+      '@api': path.resolve(__dirname, 'src/api'),
+      '@components': path.resolve(__dirname, 'src/components'),
+      '@constants': path.resolve(__dirname, 'src/constants'),
+      '@hooks': path.resolve(__dirname, 'src/hooks'),
+      '@pages': path.resolve(__dirname, 'src/pages'),
+      '@utils': path.resolve(__dirname, 'src/utils'),
+    },
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "front-react",
 			"version": "0.1.0",
 			"dependencies": {
+				"@craco/craco": "^7.1.0",
 				"@emotion/css": "^11.10.6",
 				"@emotion/eslint-plugin": "^11.10.0",
 				"@emotion/react": "^11.10.6",
@@ -1926,6 +1927,49 @@
 			"version": "10.5.0",
 			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
 			"integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="
+		},
+		"node_modules/@craco/craco": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@craco/craco/-/craco-7.1.0.tgz",
+			"integrity": "sha512-oRAcPIKYrfPXp9rSzlsDNeOaVtDiKhoyqSXUoqiK24jCkHr4T8m/a2f74yXIzCbIheoUWDOIfWZyRgFgT+cpqA==",
+			"dependencies": {
+				"autoprefixer": "^10.4.12",
+				"cosmiconfig": "^7.0.1",
+				"cosmiconfig-typescript-loader": "^1.0.0",
+				"cross-spawn": "^7.0.3",
+				"lodash": "^4.17.21",
+				"semver": "^7.3.7",
+				"webpack-merge": "^5.8.0"
+			},
+			"bin": {
+				"craco": "dist/bin/craco.js"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"peerDependencies": {
+				"react-scripts": "^5.0.0"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
 		},
 		"node_modules/@csstools/normalize.css": {
 			"version": "12.0.0",
@@ -4234,6 +4278,26 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/@tsconfig/node10": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+		},
+		"node_modules/@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+		},
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+		},
+		"node_modules/@tsconfig/node16": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+		},
 		"node_modules/@types/aria-query": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
@@ -6389,6 +6453,19 @@
 				"wrap-ansi": "^7.0.0"
 			}
 		},
+		"node_modules/clone-deep": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+			"dependencies": {
+				"is-plain-object": "^2.0.4",
+				"kind-of": "^6.0.2",
+				"shallow-clone": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6628,6 +6705,29 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/cosmiconfig-typescript-loader": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.9.tgz",
+			"integrity": "sha512-tRuMRhxN4m1Y8hP9SNYfz7jRwt8lZdWxdjg/ohg5esKmsndJIn4yT96oJVcf5x0eA11taXl+sIp+ielu529k6g==",
+			"dependencies": {
+				"cosmiconfig": "^7",
+				"ts-node": "^10.7.0"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			},
+			"peerDependencies": {
+				"@types/node": "*",
+				"cosmiconfig": ">=7",
+				"typescript": ">=3"
+			}
+		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -7249,6 +7349,14 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+		},
+		"node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
 		"node_modules/diff-sequences": {
 			"version": "27.5.1",
@@ -13194,6 +13302,11 @@
 				"semver": "bin/semver.js"
 			}
 		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+		},
 		"node_modules/makeerror": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -16724,6 +16837,17 @@
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
 			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
 		},
+		"node_modules/shallow-clone": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+			"dependencies": {
+				"kind-of": "^6.0.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -17752,6 +17876,61 @@
 			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
 			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
 		},
+		"node_modules/ts-node": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+			"dependencies": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.50",
+				"@swc/wasm": ">=1.2.50",
+				"@types/node": "*",
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ts-node/node_modules/acorn-walk": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/ts-node/node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -18065,6 +18244,11 @@
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "8.1.1",
@@ -18442,6 +18626,18 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/webpack-merge": {
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+			"integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+			"dependencies": {
+				"clone-deep": "^4.0.1",
+				"wildcard": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/webpack-sources": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
@@ -18594,6 +18790,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/wildcard": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+			"integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ=="
 		},
 		"node_modules/word-wrap": {
 			"version": "1.2.3",
@@ -19033,6 +19234,14 @@
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/yocto-queue": {
@@ -20330,6 +20539,39 @@
 			"version": "10.5.0",
 			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
 			"integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="
+		},
+		"@craco/craco": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@craco/craco/-/craco-7.1.0.tgz",
+			"integrity": "sha512-oRAcPIKYrfPXp9rSzlsDNeOaVtDiKhoyqSXUoqiK24jCkHr4T8m/a2f74yXIzCbIheoUWDOIfWZyRgFgT+cpqA==",
+			"requires": {
+				"autoprefixer": "^10.4.12",
+				"cosmiconfig": "^7.0.1",
+				"cosmiconfig-typescript-loader": "^1.0.0",
+				"cross-spawn": "^7.0.3",
+				"lodash": "^4.17.21",
+				"semver": "^7.3.7",
+				"webpack-merge": "^5.8.0"
+			}
+		},
+		"@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"requires": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"dependencies": {
+				"@jridgewell/trace-mapping": {
+					"version": "0.3.9",
+					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+					"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+					"requires": {
+						"@jridgewell/resolve-uri": "^3.0.3",
+						"@jridgewell/sourcemap-codec": "^1.4.10"
+					}
+				}
+			}
 		},
 		"@csstools/normalize.css": {
 			"version": "12.0.0",
@@ -21903,6 +22145,26 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
 			"integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
+		},
+		"@tsconfig/node10": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+		},
+		"@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+		},
+		"@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+		},
+		"@tsconfig/node16": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
 		},
 		"@types/aria-query": {
 			"version": "5.0.1",
@@ -23586,6 +23848,16 @@
 				"wrap-ansi": "^7.0.0"
 			}
 		},
+		"clone-deep": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+			"requires": {
+				"is-plain-object": "^2.0.4",
+				"kind-of": "^6.0.2",
+				"shallow-clone": "^3.0.0"
+			}
+		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -23776,6 +24048,20 @@
 				"path-type": "^4.0.0",
 				"yaml": "^1.10.0"
 			}
+		},
+		"cosmiconfig-typescript-loader": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.9.tgz",
+			"integrity": "sha512-tRuMRhxN4m1Y8hP9SNYfz7jRwt8lZdWxdjg/ohg5esKmsndJIn4yT96oJVcf5x0eA11taXl+sIp+ielu529k6g==",
+			"requires": {
+				"cosmiconfig": "^7",
+				"ts-node": "^10.7.0"
+			}
+		},
+		"create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
@@ -24209,6 +24495,11 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+		},
+		"diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
 		},
 		"diff-sequences": {
 			"version": "27.5.1",
@@ -28555,6 +28846,11 @@
 				}
 			}
 		},
+		"make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+		},
 		"makeerror": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -30909,6 +31205,14 @@
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
 			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
 		},
+		"shallow-clone": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+			"requires": {
+				"kind-of": "^6.0.2"
+			}
+		},
 		"shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -31694,6 +31998,38 @@
 			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
 			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
 		},
+		"ts-node": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+			"requires": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"dependencies": {
+				"acorn-walk": {
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+					"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+				},
+				"arg": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+					"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+				}
+			}
+		},
 		"tsconfig-paths": {
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -31914,6 +32250,11 @@
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+		},
+		"v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
 		},
 		"v8-to-istanbul": {
 			"version": "8.1.1",
@@ -32197,6 +32538,15 @@
 				}
 			}
 		},
+		"webpack-merge": {
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+			"integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+			"requires": {
+				"clone-deep": "^4.0.1",
+				"wildcard": "^2.0.0"
+			}
+		},
 		"webpack-sources": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
@@ -32298,6 +32648,11 @@
 				"has-tostringtag": "^1.0.0",
 				"is-typed-array": "^1.1.10"
 			}
+		},
+		"wildcard": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+			"integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ=="
 		},
 		"word-wrap": {
 			"version": "1.2.3",
@@ -32672,6 +33027,11 @@
 			"version": "20.2.9",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
 		},
 		"yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"dependencies": {
+		"@craco/craco": "^7.1.0",
 		"@emotion/css": "^11.10.6",
 		"@emotion/eslint-plugin": "^11.10.0",
 		"@emotion/react": "^11.10.6",
@@ -38,10 +39,14 @@
 		"workbox-streams": "^6.5.4"
 	},
 	"scripts": {
-		"start": "react-scripts start",
-		"build": "react-scripts build",
-		"test": "react-scripts test",
-		"eject": "react-scripts eject",
+		"start-backup": "react-scripts start",
+		"build-backup": "react-scripts build",
+		"test-backup": "react-scripts test",
+		"eject-backup": "react-scripts eject",
+		"start": "craco start",
+		"build": "craco build",
+		"test": "craco test",
+		"eject": "craco eject",
 		"lint": "tsc --noEmit && eslint src/**/*.ts{,x} --cache",
 		"lint:fix": "eslint src/**/*.ts{,x} --fix",
 		"prepare": "husky install"

--- a/src/components/interact/MessageWrapper/index.tsx
+++ b/src/components/interact/MessageWrapper/index.tsx
@@ -5,7 +5,7 @@ import {
 	MessageContent,
 	MessageCover,
 } from './style';
-import { SystemStatus } from '../../../types/common';
+import { SystemStatus } from '~/types/common';
 
 const onGenerateMessage = (
 	<>

--- a/src/components/interact/MuteButtonWrapper/index.tsx
+++ b/src/components/interact/MuteButtonWrapper/index.tsx
@@ -1,7 +1,7 @@
 import { MuteButton } from './style';
-import { Text } from '../../atom/Text';
+import { Text } from '@components/atom/Text';
 import { RxEyeOpen, RxEyeClosed } from 'react-icons/rx';
-import { SystemStatus } from '../../../types/common';
+import { SystemStatus } from '~/types/common';
 
 const activeMessage = <RxEyeOpen />;
 const inactiveMessage = <RxEyeClosed />;

--- a/src/components/interact/VoiceCanvas/ActionSphere.tsx
+++ b/src/components/interact/VoiceCanvas/ActionSphere.tsx
@@ -4,7 +4,7 @@ import React, { useRef } from 'react';
 import { useFrame, Object3DNode } from '@react-three/fiber';
 import { Vector3 } from 'three';
 import * as THREE from 'three';
-import { SystemStatus } from '../../../types/common';
+import { SystemStatus } from '~/types/common';
 
 interface ActionSphereProps {
 	speed: number;

--- a/src/components/interact/VoiceCanvas/MainSphere.tsx
+++ b/src/components/interact/VoiceCanvas/MainSphere.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/no-unknown-property */
 // [#14] 이슈: eslint-react와 three.js간 호환성
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Center, MeshTransmissionMaterial } from '@react-three/drei';
 import { Vector3, SphereGeometry } from 'three';
-import { SystemStatus } from '../../../types/common';
+import { SystemStatus } from '~/types/common';
 
 interface MainSphereProps {
 	systemStatus: SystemStatus;

--- a/src/components/interact/VoiceCanvas/index.tsx
+++ b/src/components/interact/VoiceCanvas/index.tsx
@@ -1,16 +1,16 @@
 /* eslint-disable react/no-unknown-property */
 // [#14] 이슈: eslint-react와 three.js간 호환성
-import React from 'react';
+
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import { Vector3 } from 'three';
-import { useControls } from 'leva';
+
 import * as THREE from 'three';
 import { EffectComposer, Bloom } from '@react-three/postprocessing';
-import CircularMesh from './CircularMesh';
+
 import MainSphere from './MainSphere';
 import ActionSphere from './ActionSphere';
-import { SystemStatus } from '../../../types/common';
+import { SystemStatus } from '~/types/common';
 
 interface RigProps {
 	systemStatus: SystemStatus;

--- a/src/hooks/useAudioStream.tsx
+++ b/src/hooks/useAudioStream.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { SystemStatus } from '../types/common';
+import { SystemStatus } from '~/types/common';
 
 const audioContext = new AudioContext();
 void audioContext.suspend();

--- a/src/hooks/useGoogleRecognition.tsx
+++ b/src/hooks/useGoogleRecognition.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { getGoogleTranscript } from '../api/googlecloud';
-import { SystemStatus } from '../types/common';
-import { blobToAudioBase64, checkMute } from '../utils/audio';
+import { getGoogleTranscript } from '@api/googlecloud';
+import { SystemStatus } from '~/types/common';
+import { blobToAudioBase64, checkMute } from '@utils/audio';
 
 const chunks: Blob[] = [];
 

--- a/src/hooks/useRecognition.tsx
+++ b/src/hooks/useRecognition.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { LANG } from '../constants/setting';
-import { SystemStatus } from '../types/common';
+import { LANG } from '@constants/setting';
+import { SystemStatus } from '~/types/common';
 
 const SpeechRecognition = window.SpeechRecognition || webkitSpeechRecognition;
 const recognition = new SpeechRecognition();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,8 +5,8 @@ import App from './App';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import reportWebVitals from './reportWebVitals';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import Interact from './pages/interact';
-import Setting from './pages/setting';
+import Interact from '@pages/interact';
+import Setting from '@pages/setting';
 import { Global } from '@emotion/react';
 
 const root = createRoot(document.getElementById('root') as HTMLElement);

--- a/src/pages/interact/index.tsx
+++ b/src/pages/interact/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import React, { useState, useEffect } from 'react';
-import { Container, Viewport } from '../../components/common';
+import { Container, Viewport } from '@components/common';
 import {
 	Toolbar,
 	ToolbarButton,
@@ -13,19 +13,19 @@ import {
 	VoiceCanvas,
 	MuteButtonWrapper,
 	MessageWrapper,
-} from '../../components/interact';
+} from '@components/interact';
 import { RxTokens, RxAccessibility, RxShadow } from 'react-icons/rx';
-import { requestChatCompletion } from '../../api/openai';
-import useAudioStream from '../../hooks/useAudioStream';
-import useGoogleRecognition from '../../hooks/useGoogleRecognition';
-import useRecognition from '../../hooks/useRecognition';
+import { requestChatCompletion } from '@api/openai';
+import useAudioStream from '@hooks/useAudioStream';
+import useGoogleRecognition from '@hooks/useGoogleRecognition';
+import useRecognition from '@hooks/useRecognition';
 import {
 	checkMute,
 	playTextToAudio,
 	stopAudio,
 	toggleSystemStatusOnVolume,
-} from '../../utils/audio';
-import { SystemStatus } from '../../types/common';
+} from '@utils/audio';
+import { SystemStatus } from '~/types/common';
 
 const dummyTitle = 'american gothics';
 

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styled from '@emotion/styled';
 
 export const CustomComponent = styled('div')`

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -1,6 +1,6 @@
 import React from 'react';
-import { SystemStatus } from '../types/common';
-import { getGoogleTextToSpeech } from '../api/googlecloud';
+import { SystemStatus } from '~/types/common';
+import { getGoogleTextToSpeech } from '@api/googlecloud';
 
 const ACTIVATION_VOLUME = 80;
 const DEACTIVATION_VOLUME = 40;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,9 +20,10 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "jsxImportSource": "@emotion/react"
+    "jsxImportSource": "@emotion/react",
   },
   "include": [
     "src",
-  ]
+  ],
+  "extends": "./tsconfig.paths.json" 
 }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+      "baseUrl": ".",
+      "paths": {
+        "~/*": ["src/*"],
+        "@api/*":["src/api/*"],
+        "@components/*":["src/components/*"],
+        "@constants/*":["src/constants/*"],
+        "@hooks/*":["src/hooks/*"],
+        "@pages/*":["src/pages/*"],
+        "@utils/*":["src/utils/*"],
+      }
+  }
+}


### PR DESCRIPTION
# 요약
- path alias 적용

# 상세
- path alias 적용 위해 tsconfig.json 및 tsconfig.path.js 에 path 명시
- webpack 설정 변경 위해 craco 설치 및 설정 추가
- pkg script 에 react-script 는 백업 후 craco script 추가

# 이슈
- types 는 @types 를 사용할 수 없어서 루트(~/) 에서 접근
- eslint.config 에서 "plugin:import/recommended" 가 path alias 관련해서 warning 을 발생시키는 것 같아 'eslint-import-resolver-alias' 라이브러리를 이용해서 해결하려 했으나, 에디터를 껐다 켰더니 문제가 사라져서 일단 보류 상태. 추후 해당 문제가 발생한다면 상기 라이브러리를 설치하여 해결하면 될 것으로 보임


close #13 