### PR TITLE
Fix/#21 audio stream inclusion

### DIFF
--- a/src/api/googlecloud.ts
+++ b/src/api/googlecloud.ts
@@ -56,10 +56,12 @@ interface IGoogleTextToSpeechResponse {
 }
 
 export async function getGoogleTranscript(blobString: string) {
-	if (blobString.length === 0) return '';
+	if (!blobString || blobString.length === 0) {
+		return Promise.reject('Google STT input is empty');
+	}
+
 	if (blobString.length > MAX_TRANS_LENGTH) {
-		alert('maximum speech length reached');
-		return '';
+		return Promise.reject('Google STT input is too long');
 	}
 	try {
 		const res = await fetch(
@@ -79,6 +81,9 @@ export async function getGoogleTranscript(blobString: string) {
 		);
 		const data = (await res.json()) as IGoogleTranscriptResponse;
 		const results = data.results;
+		console.log(data);
+		if (results === undefined)
+			return await Promise.reject('Google STT reponse is empty');
 		const [{ alternatives }] = results ? results : [{ alternatives: null }];
 		const [{ transcript }] = alternatives ? alternatives : [{ transcript: '' }];
 		return transcript;

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -36,7 +36,7 @@ const configuration = new Configuration({
 
 const promptBase = (() => {
 	if ((LANG as LANGUAGE) === LANGUAGE.KR) {
-		return '이것은 상황극입니다. 다음의 질문에 대해 클로드 모네의 입장에서 대답하시오. 질문: ';
+		return '당신은 클로드 모네입니다. 질문에 대해 클로드 모네의 입장에서 대답하시오. 질문: ';
 	} else if ((LANG as LANGUAGE) === LANGUAGE.US) {
 		return 'this is role play. answer to following question as a Claude Monet. question: ';
 	}

--- a/src/hooks/useAudioStream.tsx
+++ b/src/hooks/useAudioStream.tsx
@@ -24,6 +24,7 @@ interface UseAudioStreamProps {
 
 function useAudioStream({ systemStatus }: UseAudioStreamProps) {
 	const volumeIntervalRef = useRef<NodeJS.Timer | null>(null);
+	const anchorIntervalRef = useRef<NodeJS.Timer | null>(null);
 	const [volume, setVolume] = useState<number>(0);
 	const [stream, setStream] = useState<MediaStream | null>(null);
 	const [streamAnchor, setStreamAnchor] = useState<object>({});
@@ -33,12 +34,13 @@ function useAudioStream({ systemStatus }: UseAudioStreamProps) {
 		volumeIntervalRef.current = setInterval(() => {
 			setVolume(getVolume(analyserNode));
 		}, VOLUME_ANALYSIS_INTERVAL);
-		const anchorInterval = setInterval(() => {
+		if (anchorIntervalRef.current) clearInterval(anchorIntervalRef.current);
+		anchorIntervalRef.current = setInterval(() => {
 			setStreamAnchor({});
-			// clearTimeout(anchorInterval);
 		}, STREAM_REFRESH_INTERVAL);
 		return () => {
-			clearInterval(anchorInterval);
+			if (volumeIntervalRef.current) clearInterval(volumeIntervalRef.current);
+			if (anchorIntervalRef.current) clearInterval(anchorIntervalRef.current);
 		};
 	}, []);
 

--- a/src/hooks/useAudioStream.tsx
+++ b/src/hooks/useAudioStream.tsx
@@ -33,15 +33,18 @@ function useAudioStream({ systemStatus }: UseAudioStreamProps) {
 		volumeIntervalRef.current = setInterval(() => {
 			setVolume(getVolume(analyserNode));
 		}, VOLUME_ANALYSIS_INTERVAL);
-		const anchorInterval = setTimeout(() => {
+		const anchorInterval = setInterval(() => {
 			setStreamAnchor({});
-			clearTimeout(anchorInterval);
+			// clearTimeout(anchorInterval);
 		}, STREAM_REFRESH_INTERVAL);
+		return () => {
+			clearInterval(anchorInterval);
+		};
 	}, []);
 
 	useEffect(() => {
 		if (audioContext.state === 'suspended') void audioContext.resume();
-		if (systemStatus !== SystemStatus.LISTEN) {
+		if ([SystemStatus.HIBERNATE, SystemStatus.SPEAK].includes(systemStatus)) {
 			if (stream !== null) {
 				stream.getAudioTracks().forEach((track) => {
 					track.stop();

--- a/src/hooks/useGoogleRecognition.tsx
+++ b/src/hooks/useGoogleRecognition.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { getGoogleTranscript } from '../api/googlecloud';
 import { SystemStatus } from '../types/common';
 import { blobToAudioBase64, checkMute } from '../utils/audio';
@@ -17,9 +17,7 @@ function useGoogleRecognition({
 	setSystemStatus,
 }: IUseGoogleRecognitionProps) {
 	const [transcript, setTranscript] = useState<string>('');
-	const [mediaRecorder, setMediaRecorder] = useState<MediaRecorder | null>(
-		null
-	);
+	const mediaRecorder = useRef<MediaRecorder | null>(null);
 
 	useEffect(() => {
 		if (stream) {
@@ -34,9 +32,9 @@ function useGoogleRecognition({
 				const script = await getGoogleTranscript(blobBase64);
 				setTranscript(script);
 			};
-			setMediaRecorder(newRecorder);
+			mediaRecorder.current = newRecorder;
 		} else {
-			setMediaRecorder(null);
+			mediaRecorder.current = null;
 		}
 	}, [stream]);
 
@@ -44,15 +42,15 @@ function useGoogleRecognition({
 		if (systemStatus !== SystemStatus.GENERATE) setTranscript('');
 		if (
 			systemStatus === SystemStatus.LISTEN &&
-			mediaRecorder?.state === 'inactive'
+			mediaRecorder.current?.state === 'inactive'
 		) {
 			chunks.splice(0);
-			mediaRecorder.start();
+			mediaRecorder.current.start();
 		} else if (
 			systemStatus !== SystemStatus.LISTEN &&
-			mediaRecorder?.state === 'recording'
+			mediaRecorder.current?.state === 'recording'
 		) {
-			mediaRecorder.stop();
+			mediaRecorder.current.stop();
 			chunks.splice(0);
 		}
 	}, [systemStatus]);

--- a/src/pages/interact/index.tsx
+++ b/src/pages/interact/index.tsx
@@ -60,7 +60,6 @@ function Interact() {
 	const { transcript: googleTranscript } = useGoogleRecognition({
 		stream: voiceStream,
 		systemStatus,
-		setSystemStatus,
 	});
 	const { transcript: localTranscript } = useRecognition({
 		systemStatus,

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -53,7 +53,7 @@ export function toggleSystemStatusOnVolume({
 		timeoutRef.current === null
 	) {
 		timeoutRef.current = setTimeout(() => {
-			setSystemStatus(checkMute(SystemStatus.HIBERNATE));
+			setSystemStatus(checkMute(SystemStatus.TRANSCRIBE));
 			if (timeoutRef.current) {
 				clearTimeout(timeoutRef.current);
 				timeoutRef.current = null;


### PR DESCRIPTION
## 요약
- 인터벌 기반으로 오디오 스트림의 사전 생성 / 제거

## 상세
- hooks/useAudioStream의 코드 개선 및 useEffect 반환 함수로 인터벌 제거

- hooks/useGoogleRecognition에서 오디오 스트림 생성 로직 개선
  - stream의 생성 인터벌에 따라 mediaRecorder 생성 / 제거 (1초 마다 재생성)
  - systemStatus가 'TRANSCRIBE'로 토글 시 mediaRecorder의 데이터를 base64로 인코딩 및 구글 STT 호출 (재생성 로직 중단)
 
## 이슈
- 해당 내용 없음

Closes #21 